### PR TITLE
Update authenticate.py

### DIFF
--- a/server/account/authenticate.py
+++ b/server/account/authenticate.py
@@ -16,7 +16,7 @@ class CustomAuthentication(jwt_authentication.JWTAuthentication):
         raw_token = request.COOKIES.get(settings.SIMPLE_JWT['AUTH_COOKIE']) or None 
 
         if header is None:
-            return None
+            pass
         else:
             raw_token = self.get_raw_token(header)
 


### PR DESCRIPTION
if the header is None then returning None will cause the function to stop right there and the code will not be read that is below the return None. If we have a raw_token already from the cookie then it will not be even used. So don't return anything in here.